### PR TITLE
EI-1002 MAkse last_appy optional, remove timestamp

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ locals {
     builtbranch   = var.tag_git_branch
     last_apply    = var.tag_last_apply
     last_apply_by = var.tag_last_apply_by
-    timestamp     = formatdate("DDMMYY", timestamp())
+    timestamp     = var.timestamp != null ? var.timestamp : formatdate("DDMMYY", timestamp())
   }
   locations = {
     uks = "uksouth"

--- a/variables.tf
+++ b/variables.tf
@@ -125,3 +125,9 @@ variable "tag_last_apply_by" {
   type        = string
   description = "USER ID of the person who is applying the changes"
 }
+
+variable "timestamp" {
+  type        = string
+  description = "timestamp"
+  default     = null
+}


### PR DESCRIPTION
It is fixing "will be known after apply" problem. I have removed timestamp and made last_apply optional variable. It is set to current time in the module if it is sent as null. It is solving "known after apply" problem. Without this we cannot see the changes only see that there is a change. This helps but does not solve perpetual diff problem, it is another story.  

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EI-1002


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
