### PR TITLE
chore: remove validation from environment tag

### DIFF
--- a/tests/terratest/example/.terraform.lock.hcl
+++ b/tests/terratest/example/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version = "3.67.0"
+  hashes = [
+    "h1:avT/nxxzilnMJgYSn8/gP3HdQKPYv6DV/jtKL6Tfeis=",
+    "zh:1251620ab4422d7d99d197b90d4340cdbe12b147a61e72812f51b36f1dc3ec19",
+    "zh:3ff92a9be34003727e0f6e054e84a011b5fd69086cd4010e64448fae13346689",
+    "zh:4c756346347750bee17c7b0230e6c68b5a364dd64493b721330ac20c7ffa95dd",
+    "zh:70c450c6d1b52401396469c7ab2380bd441a98df8d969c0fbd9d1b9de428e3f2",
+    "zh:86cc77b87d3c59a60ed49cdeecb6ca7fa7a60ce44df08ba8c25d0f0538d04ef7",
+    "zh:8f07bebd7ff41643384e49878e5f87dde1363427e15654f682231710b9bad3c2",
+    "zh:8f76a448259c9eb268bea73b8d142bce633b6a3744218a95851d64405893716f",
+    "zh:9d1ebf32b736ec1997d7296b137e5f730a51cf0f339043c667657f95b1d99402",
+    "zh:a5098c4cdf6919bc6ce02f5d264b700107aa7eb554dc053af544932ce1ec453d",
+    "zh:ae40b553d47617d5eacf6a52ea244bb6a63366ec0fd653de42098d1e5a319ac5",
+    "zh:bb2a73dbb9c38921cde6539647de9dd62402f3633036e8480ce4386af529a757",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -24,11 +24,6 @@ variable "domain" {
 variable "environment" {
   description = "environment e.g. dev"
   type        = string
-
-  validation {
-    condition     = can(regex("^(lab|dev|dev[0-9][0-9]|nft|nft01|nft02|sit|sit01|sit02|ste|prx|prp|prd|mdv|mpd)$", var.environment))
-    error_message = "Invalid input, options: \"lab\", \"dev\", \"dev[0-9][0-9]\", \"nft\", \"nft01\", \"nft02\", \"sit\", \"sit01\", \"sit02\", \"ste\", \"prx\", \"prp\", \"prd\", \"mdv\", \"mpd\"."
-  }
 }
 
 variable "application" {


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:

### Change description ###

Removes validation for now as we have over 45 environments tags in the environment currently.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
