### PR TITLE
Convert var.environment to lower case to ensure environment tag name mapping logic is not case sensitive

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  matching_env_keys = [for x in keys(local.env_mapping) : x if contains(local.env_mapping[x], replace(var.environment, "/[0-9]/", ""))]
+  matching_env_keys = [for x in keys(local.env_mapping) : x if contains(local.env_mapping[x], lower(replace(var.environment, "/[0-9]/", "")))]
 
   tags = {
     tier               = var.tier

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ locals {
     management-layer = ["mgmt", "management", "mdv", "mpd"]
     production       = ["ptl", "prod", "prod-int", "prx", "prd"]
     development      = ["dev", "preview"]
-    staging          = ["ldata", "stg", "aat", "nle", "nonprod", "nonprodi", "prp", "preprod"]
+    staging          = ["ldata", "stg", "aat", "nle", "nonprod", "nonprodi", "prp", "preprod", "nonlive"]
     testing          = ["test", "perftest", "sit", "nft", "ste"]
     sandbox          = ["sandbox", "sbox", "ptlsbox", "sbox-int", "lab"]
     demo             = ["demo"]

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ locals {
   }
   env_mapping = {
     management-layer = ["mgmt", "management", "mdv", "mpd"]
-    production       = ["ptl", "prod", "prod-int", "prx", "prd"]
+    production       = ["ptl", "prod", "prod-int", "prx", "prd", "live"]
     development      = ["dev", "preview"]
     staging          = ["ldata", "stg", "aat", "nle", "nonprod", "nonprodi", "prp", "preprod", "nonlive"]
     testing          = ["test", "perftest", "sit", "nft", "ste"]


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-23431

### Change description
Turns out https://github.com/hmcts/cpp-terraform-azurerm-mgmt has env names in all caps and this trips up existing env mapping logic because of casing.
Convert var.environment to lower case to ensure environment name is always mapped regardless of casing.
Also add "nonlive" and "live" environment names to environments map

### Testing done
N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
